### PR TITLE
move stack to end of encodeResult object so valuable debug values are not truncated by yamlish

### DIFF
--- a/tap-producer.js
+++ b/tap-producer.js
@@ -102,11 +102,15 @@ function encodeResult (res, count, diag) {
   var d = {}
     , dc = 0
   Object.keys(res).filter(function (k) {
-    return k !== "ok" && k !== "name" && k !== "id"
+    return k !== "ok" && k !== "name" && k !== "id" && k !== 'stack'  //moving stack to end
   }).forEach(function (k) {
     dc ++
     d[k] = res[k]
   })
+  if (res.stack) { //if stack, add to end, otherwise yamlish.encode truncates valuable data
+    dc ++
+    d.stack = res.stack
+  }
   //console.error(d, "about to encode")
   if (dc > 0) output += "  ---"+yamlish.encode(d)+"\n  ...\n"
   return output


### PR DESCRIPTION
move stack to end of encodeResult object so valuable debug values are not truncated.

Previously yamlish.encode of the encodeResult debug object truncates important debug fields like
-  found
- wanted
- diff 

because the stack field occurs before the other fields when it serializes the output.

Example before this modification:

tap ./test not ok arguments-test.js ............ 5/6
    Command: "node" "arguments-test.js"
    ok 1 should be empty array
    ok 2 should be empty array
    ok 3 should be empty array
    ok 4 type is Array
    ok 5 should be similar
    not ok 6 should be equal
      ---
        file:   /Users/barczewskij/projects/ensure-array/test/arguments-test.js
        line:   33
        column: 5
        stack:
          - getCaller (/Users/barczewskij/projects/ensure-array/node_modules/tap/node_modules/tap-assert/assert.js:369:17)
          - assert (/Users/barczewskij/projects/ensure-array/node_modules/tap/node_modules/tap-assert/assert.js:17:16)
          - Function.equal (/Users/barczewskij/projects/ensure-array/node_modules/tap/node_modules/tap-assert/assert.js:158:10)
          - Test._testAssert (/Users/barczewskij/projects/ensure-array/node_modules/tap/node_modules/tap-test/test.js:86:16)
          - Test.<anonymous> (/Users/barczewskij/projects/ensure-array/test/arguments-test.js:33:5)
          - Test.<anonymous> (native)
          - Test.<anonymous> (events.js:61:17)

---

Example after this modification:

tap ./test
not ok arguments-test.js ............ 5/6
    Command: "node" "arguments-test.js"
    ok 1 should be empty array
    ok 2 should be empty array
    ok 3 should be empty array
    ok 4 type is Array
    ok 5 should be similar
    not ok 6 should be equal
      ---
        file:   /Users/barczewskij/projects/ensure-array/test/arguments-test.js
        line:   33
        column: 5
        found:  foo
        wanted: bar
        diff:   |
          FOUND:  foo
          WANTED: bar
                  ^ (at position = 0)
        unique: 5
        stack:
          - getCaller (/Users/barczewskij/projects/ensure-array/node_modules/tap/node_modules/tap-assert/assert.js:369:17)
          - assert (/Users/barczewskij/projects/ensure-array/node_modules/tap/node_modules/tap-assert/assert.js:17:16)
          - Function.equal (/Users/barczewskij/projects/ensure-array/node_modules/tap/node_modules/tap-assert/assert.js:158:10)
          - Test._testAssert (/Users/barczewskij/projects/ensure-array/node_modules/tap/node_modules/tap-test/test.js:86:16)
